### PR TITLE
Added KudoBoard Primitive version

### DIFF
--- a/src/pageContent/Kudos/index.tsx
+++ b/src/pageContent/Kudos/index.tsx
@@ -1,21 +1,28 @@
 import React from "react";
-import { Content, ContentCard} from "pinus-ui-library";
-import { getPeopleKudos } from "src/utils/contentful/kudo_read";
-import { ContentfulKudos } from "src/utils/contentful/types";
+import { Content, ContentCard, Text} from "pinus-ui-library";
 
 
 const KudosContent = (props) => {
     const Kudos = props.kudos.contents;
-    return (
-      <>
-      <div className={`container mx-auto flex flex-wrap`}>  
-        {Kudos.map(kudo =>
-          <div className={`flex-none min-w-0 m-10`}>
+    const hasKudos = Kudos !== undefined;
+    return (<>
+      {hasKudos && 
+        <div className={`container mx-auto flex flex-wrap justify-evenly mt-4 gap-4`}>  
+          {Kudos.map(kudo =>
+            <div className={`flex-1 min-w-0`}>
               <ContentCard hyperlink="" title={kudo.text} description={kudo.writer}/>
-          </div>
-          )} 
-      </div>
-      
+            </div>
+          )}
+        </div>
+      }
+      {
+        !hasKudos && 
+        <div className={`container text-center`}>
+          <Text>
+            Be the first to give Kudos to {props.person}
+          </Text>
+        </div>
+      } 
       </>
     );
   };

--- a/src/pageContent/Kudos/index.tsx
+++ b/src/pageContent/Kudos/index.tsx
@@ -8,9 +8,14 @@ const KudosContent = (props) => {
     const Kudos = props.kudos.contents;
     return (
       <>
-      <div>
-        {Kudos.map(kudo => <ContentCard hyperlink="" title={kudo.text} description={kudo.writer}/>)}
+      <div className={`container mx-auto flex`}>  
+        {Kudos.map(kudo =>
+          <div className={`flex-1 min-w-0 m-10`}>
+              <ContentCard hyperlink="" title={kudo.text} description={kudo.writer}/>
+          </div>
+          )} 
       </div>
+      
       </>
     );
   };

--- a/src/pageContent/Kudos/index.tsx
+++ b/src/pageContent/Kudos/index.tsx
@@ -8,9 +8,9 @@ const KudosContent = (props) => {
     const Kudos = props.kudos.contents;
     return (
       <>
-      <div className={`container mx-auto flex`}>  
+      <div className={`container mx-auto flex flex-wrap`}>  
         {Kudos.map(kudo =>
-          <div className={`flex-1 min-w-0 m-10`}>
+          <div className={`flex-none min-w-0 m-10`}>
               <ContentCard hyperlink="" title={kudo.text} description={kudo.writer}/>
           </div>
           )} 

--- a/src/pageContent/Kudos/index.tsx
+++ b/src/pageContent/Kudos/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Content, ContentCard} from "pinus-ui-library";
+import { getPeopleKudos } from "src/utils/contentful/kudo_read";
+import { ContentfulKudos } from "src/utils/contentful/types";
+
+
+const KudosContent = (props) => {
+    const Kudos = props.kudos.contents;
+    return (
+      <>
+      <div>
+        {Kudos.map(kudo => <ContentCard hyperlink="" title={kudo.text} description={kudo.writer}/>)}
+      </div>
+      </>
+    );
+  };
+  export default KudosContent;

--- a/src/pages/kudos/[...slug].tsx
+++ b/src/pages/kudos/[...slug].tsx
@@ -1,0 +1,21 @@
+import { NextPage } from 'next'
+import Page from 'src/components/Page'
+import {Text} from "pinus-ui-library"
+
+const KudosNotFound : NextPage = () => {
+    return (
+      <Page
+        bgImage=""
+        title="Kudos"
+        subBanner
+        description={`There is no-one here`}
+      >
+          <div className="text-center">
+            <Text> Person Not Found Sadge :( </Text>
+          </div>
+        
+      </Page>
+        
+    )
+}
+export default KudosNotFound

--- a/src/pages/kudos/[slug].tsx
+++ b/src/pages/kudos/[slug].tsx
@@ -23,10 +23,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const name = params.slug;
-  console.log(name);
-  console.log("hello");
   const contents = await getPeopleKudos(name);
-  console.log(contents);
+  
   return {
     props: {
       contents
@@ -38,7 +36,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 const KudosPerson : NextPage = (props) => {
   const router = useRouter();
   const { slug } = router.query;
-  console.log(props);
   return (
     <Page
       bgImage=""

--- a/src/pages/kudos/[slug].tsx
+++ b/src/pages/kudos/[slug].tsx
@@ -24,7 +24,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const name = params.slug;
   const contents = await getPeopleKudos(name);
-  
+  if(contents === undefined) {
+    return { props:{}};
+  }
   return {
     props: {
       contents
@@ -44,7 +46,7 @@ const KudosPerson : NextPage = (props) => {
       description={`Hello ${slug}, kudos for you are down below !`}
     >
       <div>
-        <KudosContent kudos = {props}/>
+        <KudosContent kudos = {props} person= {slug}/>
       </div>
     </Page>
       

--- a/src/pages/kudos/[slug].tsx
+++ b/src/pages/kudos/[slug].tsx
@@ -1,0 +1,57 @@
+import { useRouter } from 'next/router'
+import KudosContent from 'src/pageContent/Kudos'
+import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
+import Page from 'src/components/Page'
+import { getPeopleKudos, getPeopleSlugsFromKudoboard } from 'src/utils/contentful/kudo_read'
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const docs = await getPeopleSlugsFromKudoboard();
+
+  const paths = docs.map((name) => {
+    const slug = name.toLowerCase().replace(/ /g, '-');
+    return {
+      params: {slug}
+    };
+  });
+
+  console.debug(`Generated static paths: ${JSON.stringify(paths)}`);
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const name = params.slug;
+  console.log(name);
+  console.log("hello");
+  const contents = await getPeopleKudos(name);
+  console.log(contents);
+  return {
+    props: {
+      contents
+    }
+  };
+}
+
+
+const KudosPerson : NextPage = (props) => {
+  const router = useRouter();
+  const { slug } = router.query;
+  console.log(props);
+  return (
+    <Page
+      bgImage=""
+      title="Kudos"
+      subBanner
+      description={`Hello ${slug}, kudos for you are down below !`}
+    >
+      <div>
+        <KudosContent kudos = {props}/>
+      </div>
+    </Page>
+      
+  )
+}
+
+export default KudosPerson;

--- a/src/pages/kudos/index.tsx
+++ b/src/pages/kudos/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { NextPage } from "next";
 import Page from "src/components/Page";
-import EventsContent from "src/pageContent/Events";
 
 const Kudos: NextPage = () => {
   return (
@@ -11,7 +10,7 @@ const Kudos: NextPage = () => {
       subBanner
       description="Drop your kudos down below !"
     >
-      
+    Kudos UI to  write  
     </Page>
   );
 };

--- a/src/pages/kudos/index.tsx
+++ b/src/pages/kudos/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { NextPage } from "next";
+import Page from "src/components/Page";
+import EventsContent from "src/pageContent/Events";
+
+const Kudos: NextPage = () => {
+  return (
+    <Page
+      bgImage=""
+      title="Kudos"
+      subBanner
+      description="Drop your kudos down below !"
+    >
+      
+    </Page>
+  );
+};
+
+export default Kudos;

--- a/src/utils/contentful/kudo_read.tsx
+++ b/src/utils/contentful/kudo_read.tsx
@@ -1,0 +1,45 @@
+import { createClient, Entry } from "contentful";
+import { ContentfulDocMeta, ContentfulKudoBoard, ContentfulKudos, ContentfulPerson } from "src/utils/contentful/types";
+
+export async function getPeopleSlugsFromKudoboard(): Promise<string[]> {
+    const client = createClient({
+      space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
+      accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_KEY,
+    });
+
+    const res = await client.getEntries<ContentfulKudoBoard>({
+      content_type: "kudoboard",
+    });
+    const people = res.items[0].fields.people;
+    return people.map(x => x.fields.name);
+  }
+
+export async function getPeopleKudos(person):Promise<ContentfulKudos[]> {
+  const client = createClient({
+    space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
+    accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_KEY,
+  });
+
+  const changeSlugToName = (slug) => {
+    let str = slug.replace(/-/g ," ");
+    console.log("KWKWK");
+    console.log(str);
+    var splitStr = str.toLowerCase().split(' ');
+    for (var i = 0; i < splitStr.length; i++) {
+        splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);     
+    }
+    return splitStr.join(' '); 
+  }
+  console.log("Hello Panda");
+  console.log(changeSlugToName(person));
+  console.log("Hello Pinda");
+  const res = await client.getEntries<ContentfulPerson>({
+    content_type: "person",
+    'fields.name': changeSlugToName(person),
+  });
+  
+  console.log(res);
+  const contents = res.items[0].fields.content;
+  return contents.map(x => x.fields);
+  
+}

--- a/src/utils/contentful/kudo_read.tsx
+++ b/src/utils/contentful/kudo_read.tsx
@@ -32,8 +32,10 @@ export async function getPeopleKudos(person):Promise<ContentfulKudos[]> {
     content_type: "person",
     'fields.name': changeSlugToName(person),
   });
-  
   const contents = res.items[0].fields.content;
+  if(contents[0].fields === undefined) {
+    return;
+  }
   return contents.map(x => x.fields);
   
 }

--- a/src/utils/contentful/kudo_read.tsx
+++ b/src/utils/contentful/kudo_read.tsx
@@ -22,23 +22,17 @@ export async function getPeopleKudos(person):Promise<ContentfulKudos[]> {
 
   const changeSlugToName = (slug) => {
     let str = slug.replace(/-/g ," ");
-    console.log("KWKWK");
-    console.log(str);
     var splitStr = str.toLowerCase().split(' ');
     for (var i = 0; i < splitStr.length; i++) {
         splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);     
     }
     return splitStr.join(' '); 
   }
-  console.log("Hello Panda");
-  console.log(changeSlugToName(person));
-  console.log("Hello Pinda");
   const res = await client.getEntries<ContentfulPerson>({
     content_type: "person",
     'fields.name': changeSlugToName(person),
   });
   
-  console.log(res);
   const contents = res.items[0].fields.content;
   return contents.map(x => x.fields);
   

--- a/src/utils/contentful/types.tsx
+++ b/src/utils/contentful/types.tsx
@@ -25,3 +25,15 @@ export interface ContentfulDocMeta {
   slug?: string;
   post?: Document;
 }
+export interface ContentfulKudoBoard{
+  name: string,
+  people: Entry<ContentfulPerson>[]
+}
+export interface ContentfulPerson{
+  name: string,
+  content: Entry<ContentfulKudos>[]
+}
+export interface ContentfulKudos{
+  text: string;
+  writer: string;
+}


### PR DESCRIPTION
### Summary 

Added kudoboard. Route to see is /kudos/<Person name separated by dash>
Person Name corresponds to the name field in contentful. For example:
Simon Julian Lauw => simon-julian-law
Added missing person page with route /kudos/<InvalidName>
Added empty page

### Detail
Added new Page for KudoBoard and handled case of empty kudos for a certain user and missing users

### Pictures / Gif 

![ss (2)](https://user-images.githubusercontent.com/65953327/154063733-00b77dc6-80a6-431f-b9c4-e37dda851e49.png)

### Checks 
- [ ] Bernard
